### PR TITLE
Event Tab and Button Styling

### DIFF
--- a/src/assets/js/pages/EventPage/components/CheckinStatistics.js
+++ b/src/assets/js/pages/EventPage/components/CheckinStatistics.js
@@ -13,8 +13,10 @@ export default class CheckinStatistics extends React.Component {
     let {event, statistics} = this.props;
 
     return (
-      <Link to={`/admin/checkin/${event.alias}`} className="btn event-page__btn rounded-button rounded-button--small">
-        {statistics.checkedIn} Checked In <FA name='arrow-right' />
+      <Link to={`/admin/checkin/${event.alias}`}
+        className={`btn event-page__btn rounded-button
+          rounded-button--small rounded-button--arrow`}>
+        {statistics.checkedIn} Checked In
       </Link>
     );
   }

--- a/src/assets/js/pages/EventPage/components/ResumeStatistics.js
+++ b/src/assets/js/pages/EventPage/components/ResumeStatistics.js
@@ -7,7 +7,8 @@ import FA from 'react-fontawesome';
 export default class ResumeStatistics extends React.Component {
   static propTypes = {
     event: PropTypes.object.isRequired,
-    statistics: PropTypes.object
+    statistics: PropTypes.object,
+    className: PropTypes.string
   };
 
   /**
@@ -26,14 +27,17 @@ export default class ResumeStatistics extends React.Component {
   }
 
   render() {
-    let {event, statistics} = this.props;
+    let {event, statistics, className} = this.props;
     let resumes = statistics.resumes;
 
     return (
-      <Link to={`/admin/resumes/${event.alias}`} 
-        className="btn event-page__btn rounded-button rounded-button--small">
+      <Link to={`/admin/resumes/${event.alias}`}
+        className={`btn event-page__btn rounded-button
+          rounded-button--small pr-xl-4 ${className}`}>
         {resumes} Available Resume{resumes === 1 ? ' ' : 's '}
-        {this.renderHelpTooltip()}
+        <span className="rounded-button__right">
+          {this.renderHelpTooltip()}
+        </span>
       </Link>
     );
   }

--- a/src/assets/js/pages/EventPage/index.js
+++ b/src/assets/js/pages/EventPage/index.js
@@ -224,35 +224,44 @@ class EventPage extends React.Component {
         </div>
         <div className="container-fluid">
           <div className="row event-page__header">
-            <div className={'col-lg-auto d-flex flex-column flex-lg-row align-items-center ' +
-              ' '}>
+            <div className={`col-6 col-xl-auto d-flex flex-column flex-xl-row
+              align-items-center justify-content-center`}>
               <img className="event-page__logo" src={event.logo} />
-              <a target="_blank" href={event.homepage}>
+              <a target="_blank" rel="noopener noreferrer"
+                href={event.homepage}>
                 <h1 className="event-page__title">{event.name}</h1>
               </a>
             </div>
-            <div className="col-lg-auto ml-auto d-flex flex-column flex-lg-row align-items-center">
-              <Link to={`/admin/users/${event.alias}`} className="btn event-page__btn rounded-button rounded-button--small">
+            <div className={`col-6 col-xl-auto ml-auto d-flex flex-column
+              flex-xl-row align-items-center justify-content-center`}>
+              <Link to={`/admin/users/${event.alias}`} className={`btn
+                event-page__btn rounded-button rounded-button--small
+                d-none d-md-block`}>
                 View All Users
               </Link>
-              <CheckinStatistics event={event} statistics={statistics} />
-              <ResumeStatistics event={event} statistics={statistics} />
 
-              <Link to={`/register/${event.alias}`} className="btn event-page__btn rounded-button rounded-button--small">
-                Go To Form&nbsp;<FA name='arrow-right' />
+              <CheckinStatistics event={event} statistics={statistics}/>
+              <ResumeStatistics event={event} statistics={statistics}
+                className="d-none d-md-block" />
+
+              <Link to={`/register/${event.alias}`} className={`btn
+                event-page__btn rounded-button rounded-button--small
+                rounded-button--arrow`}>
+                Go To Form
               </Link>
             </div>
           </div>
 
           <div className="row event-tab__container">
             <div className="col">
-              <Nav tabs>
+              <Nav tabs className="event-tab__tabs">
                 {this.tabPages.map((page) => (
                   <NavItem key={page.anchor} className="event-tab__nav">
                     <NavLink href={`#${page.anchor}`}
                       className="event-tab__link"
                       active={page === activeTab}>
-                      <FA name={page.icon} /> {page.name}
+                      <FA name={page.icon}
+                        className="event-tab__icon" /> {page.name}
                     </NavLink>
                   </NavItem>
                 ))}

--- a/src/assets/scss/components/_event-tab.scss
+++ b/src/assets/scss/components/_event-tab.scss
@@ -11,6 +11,14 @@
     margin-bottom: -2px !important;
   }
 
+  &__tabs {
+    border: none;
+
+    @include media-breakpoint-down(sm) {
+      margin-bottom: 0.3rem;
+    }
+  }
+
   &__link {
     $active-color: $admin-blue;
     $tab-radius: 0.2rem;
@@ -23,10 +31,20 @@
     border: 1px solid transparent !important;
     border-top: 3px solid transparent !important;
 
+    @include media-breakpoint-down(sm) {
+      border-radius: $tab-radius !important;
+      padding: 0.25rem 0.5rem;
+      font-size: 0.9rem;
+    }
+
     &.active {
       background: $body-background !important;
       color: $black !important;
       border-color: $active-color $medium-gray transparent !important;
+      
+      @include media-breakpoint-down(sm) {
+        border-color: $active-color $medium-gray $medium-gray !important;
+      }
 
       .fa {
         color: $black;
@@ -35,6 +53,12 @@
 
     .fa {
       color: $medium-gray;
+    }
+  }
+
+  &__icon {
+    @include media-breakpoint-down(sm) {
+      display: none !important;
     }
   }
 }

--- a/src/assets/scss/components/_rounded-button.scss
+++ b/src/assets/scss/components/_rounded-button.scss
@@ -1,4 +1,7 @@
 .rounded-button {
+  $right-item-offset: 0.8rem;
+  $right-item-padding: 2rem;
+
   font-family: $input-font-family;
   width: 100%;
   max-width: 15rem;
@@ -9,6 +12,7 @@
   padding: 0.6rem 0rem;
   cursor: pointer;
   border: none;
+  position: relative;
 
   @include media-breakpoint-down(sm) {
     max-width: none;
@@ -75,5 +79,35 @@
     &:hover, &:focus {
       background-color: darken($default-red, 3%);
     }
+  }
+
+  &--arrow {
+    position: relative;
+    
+    @include media-breakpoint-up(xl) {
+      padding-right: 1.7rem;
+    }
+
+    &:before {
+      content: "\f061";
+      font: normal normal normal 14px/1 'FontAwesome';
+      position: absolute;
+      height: 100%;
+      display: flex;
+      align-items: center;
+      font-size: inherit;
+      top: 0;
+      right: $right-item-offset;
+    }
+  }
+
+  &__right {
+    position: absolute;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    font-size: inherit;
+    top: 0;
+    right: $right-item-offset;
   }
 }

--- a/src/assets/scss/pages/_event.scss
+++ b/src/assets/scss/pages/_event.scss
@@ -8,26 +8,21 @@
   &__logo {
     max-height: 5rem;
 
-    @include media-breakpoint-up(lg) {
+    @include media-breakpoint-up(xl) {
       margin-right: 1rem;
     }
   }
 
   &__title {
     display: inline-block;
-    margin-bottom: 0.5rem;
+    margin-bottom: 0;
     flex: 1;
-
-    @include media-breakpoint-up(lg) {
-      margin-bottom: 0;
-    }
   }
 
   &__btn {
-    padding: 0.5rem 0.3rem;
     margin-bottom: 0.25rem;
 
-    @include media-breakpoint-up(lg) {
+    @include media-breakpoint-up(xl) {
       margin-bottom: 0;
       & + & {
         margin-left: 1rem;


### PR DESCRIPTION
- Smaller tab names without icons for mobile devices.
- Removed "View All Users" and "Available Resumes" buttons for mobile because those pages aren't accessible on mobiles anyway.
- Made the arrows (and the tooltip) on the buttons right-aligned using pseudo-elements, so text remains centred.

Preview of mobile view:
![image](https://user-images.githubusercontent.com/1841682/52395773-38d39f80-2a64-11e9-9751-3700e2443618.png)