### PR TITLE
Fixed Misplaced Email Assets

### DIFF
--- a/src/views/emails/confirmation/html.pug
+++ b/src/views/emails/confirmation/html.pug
@@ -22,6 +22,6 @@ html
                 | Exciting news! We’ve just received your application to #{event.name}! One thing though: we need you to confirm your email here:
                 br
                 a(href=confirmUrl)
-                  img.button(src="https://s3-us-west-1.amazonaws.com/sdhacks2017-production/assets/email-confirm-button.png")
+                  img.button(src="https://s3-us-west-1.amazonaws.com/tesc-checkin/public/email-assets/email-confirm-button.png")
                 p.refer-text If that link doesn’t work, copy paste this into your browser:
                 a.refer-link(href=confirmUrl) #{confirmUrl}

--- a/src/views/emails/forgot/html.pug
+++ b/src/views/emails/forgot/html.pug
@@ -22,6 +22,6 @@ html
                 | No problem! Here's a link you can use to reset your password:
                 br
                 a(href=resetUrl)
-                  img.button(src="https://s3-us-west-1.amazonaws.com/sdhacks2017-production/assets/email-reset-button.png")
+                  img.button(src="https://s3-us-west-1.amazonaws.com/tesc-checkin/public/email-assets/email-refer-button.png")
                 p.refer-text If that link doesn’t work, copy paste this into your browser:
                 a.refer-link(href=resetUrl) #{resetUrl}


### PR DESCRIPTION
The confirm and reset images were still in the SDHacks2017-production S3 bucket, rather than in tesc-checkin. I moved across the assets in S3 and updated the locations.