### PR TITLE
Added Secure Password Resets

### DIFF
--- a/migrations/18-add_account_resets.js
+++ b/migrations/18-add_account_resets.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports.id = 'add_account_resets';
+
+module.exports.up = function (done) {
+  this.db.createCollection('accountresets', done);
+};
+
+module.exports.down = function (done) {
+  this.db.dropCollection('accountresets', done);
+};

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "passport": "^0.4.0",
     "passport-jwt": "^3.0.1",
     "passport-local": "^1.0.0",
-    "password-generator": "^2.2.0",
     "popper.js": "^1.12.9",
     "pug": "^2.0.0-rc.4",
     "react": "^16.0.0",

--- a/src/client/auth/user/Reset.tsx
+++ b/src/client/auth/user/Reset.tsx
@@ -30,9 +30,9 @@ class Reset extends React.Component<Props, ResetState> {
     isErrorVisible: false,
   };
 
-  componentDidReceiveProps(newProps: Props) {
+  componentDidUpdate(newProps: Props) {
     // Show error message if new one appears
-    if (newProps.errorMessage) {
+    if (this.props.errorMessage !== newProps.errorMessage) {
       this.setState({
         isErrorVisible: true,
       });

--- a/src/client/data/User.ts
+++ b/src/client/data/User.ts
@@ -59,15 +59,15 @@ export const forgotPassword = (email: string) => {
 
 /**
  * Resets the password for the given user.
- * @param {String} id The ID of the account to reset.
+ * @param {String} resetString The reset string associated with the request.
  * @param {String} newPassword The new password to associate with the user.
  * @returns {Promise} A promise of the request.
  */
-export const resetPassword = (id: string, newPassword: string) => {
+export const resetPassword = (resetString: string, newPassword: string) => {
   return promisify<SuccessResponse>(request
     .post('/reset')
     .set('Content-Type', 'application/json')
-    .send({id, newPassword} as ResetPasswordRequest)
+    .send({resetString, newPassword} as ResetPasswordRequest)
     .use(prefix)
     .use(nocache));
 };

--- a/src/client/pages/LoginPage.tsx
+++ b/src/client/pages/LoginPage.tsx
@@ -45,6 +45,14 @@ class LoginPage extends AlertPage<Props, LoginPageState> {
         } as PageAlert],
         redirectToReferrer: this.state.redirectToReferrer,
       };
+    } else if (props.location.hash === '#reset') {
+      this.state = {
+        alerts: [...this.state.alerts, {
+          type: AlertType.Success,
+          message: 'You have successfully reset your password',
+        } as PageAlert],
+        redirectToReferrer: this.state.redirectToReferrer,
+      };
     }
   }
 

--- a/src/client/pages/ResetPage.tsx
+++ b/src/client/pages/ResetPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { RouteComponentProps } from 'react-router-dom';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
 import Reset, { ResetFormData } from '~/auth/user/Reset';
 import { resetPassword } from '~/data/User';
 
@@ -9,7 +9,7 @@ interface ResetPageState {
 }
 
 type Props = RouteComponentProps<{
-  id: string;
+  resetString: string;
 }>;
 
 class ResetPage extends React.Component<Props, ResetPageState> {
@@ -33,8 +33,11 @@ class ResetPage extends React.Component<Props, ResetPageState> {
       };
     }
 
-    return resetPassword(this.props.match.params.id, values.newPassword)
-      .then(() => this.setState({success: 'Your password has been reset'}))
+    return resetPassword(this.props.match.params.resetString, values.newPassword)
+      .then(() => {
+        this.setState({success: 'Your password has been reset'});
+        this.props.history.push('/login#reset');
+      })
       .catch((e) => this.setState({error: e.message}));
   }
 
@@ -49,4 +52,4 @@ class ResetPage extends React.Component<Props, ResetPageState> {
   }
 }
 
-export default ResetPage;
+export default withRouter(ResetPage);

--- a/src/client/routes.tsx
+++ b/src/client/routes.tsx
@@ -208,7 +208,7 @@ class Routes extends React.Component<Props> {
           component={this.renderUser(ForgotPage)}
         />
         <Route
-          path="/user/reset/:id"
+          path="/user/reset/:resetString"
           component={this.renderUser(ResetPage)}
         />
         <Route

--- a/src/server/api/controllers/UserAuthController.ts
+++ b/src/server/api/controllers/UserAuthController.ts
@@ -58,13 +58,15 @@ export class UserAuthController {
       throw new Error(ErrorMessage.NO_ACCOUNT_EXISTS());
     }
 
-    await this.EmailService.sendPasswordResetEmail(req, account);
+    const newReset = await this.UserService.createAccountReset(account);
+
+    await this.EmailService.sendPasswordResetEmail(req, account, newReset);
     return SuccessResponse.Positive;
   }
 
   @Post('/reset')
   async resetPassword(@Body() body: ResetPasswordRequest) {
-    await this.UserService.resetUserPassword(body.id, body.newPassword);
+    await this.UserService.resetUserPassword(body.resetString, body.newPassword);
     return SuccessResponse.Positive;
   }
 

--- a/src/server/models/AccountReset.ts
+++ b/src/server/models/AccountReset.ts
@@ -1,0 +1,35 @@
+import { AccountPasswordReset } from '@Shared/ModelTypes';
+import { Model, Schema, model, Document } from 'mongoose';
+import * as mongooseDelete from 'mongoose-delete';
+import { Container } from 'typedi';
+
+export type AccountResetDocument = AccountPasswordReset & Document;
+export type AccountResetModel = Model<AccountResetDocument>;
+
+const AccountResetSchema = new Schema({
+  // Declares the account that will be reset
+  account: {
+    type: Schema.Types.ObjectId,
+    ref: 'Account',
+  },
+  // Declares the URL string which references this reset
+  resetString: {
+    type: String,
+    unique: true,
+  },
+  // Declares until when this reset is active
+  expires: {
+    type: Date,
+  },
+  // Declares whether the reset is still allowed (hasn't been used)
+  valid: {
+    type: Boolean,
+    default: true,
+  },
+}, {timestamps: true});
+
+AccountResetSchema.plugin(mongooseDelete);
+
+export const RegisterModel = () =>
+  Container.set('AccountResetModel', model<AccountResetDocument,
+    AccountResetModel>('AccountReset', AccountResetSchema));

--- a/src/server/models/index.ts
+++ b/src/server/models/index.ts
@@ -1,4 +1,5 @@
 import { RegisterModel as Account } from './Account';
+import { RegisterModel as AccountResetModel } from './AccountReset';
 import { RegisterModel as Admin } from './Admin';
 import { RegisterModel as Download } from './Download';
 import { RegisterModel as Event } from './Event';
@@ -7,6 +8,7 @@ import { RegisterModel as User } from './User';
 
 export const RegisterModels = () => {
   Account();
+  AccountResetModel();
   Admin();
   Download();
   Event();

--- a/src/server/services/EmailService.ts
+++ b/src/server/services/EmailService.ts
@@ -1,21 +1,18 @@
 import { Logger } from '@Config/Logging';
 import { createTESCEmail, createEventEmail } from '@Config/Mailer';
-import { UserModel, UserDocument } from '@Models/User';
-import { EventModel } from '@Models/Event';
-import { TESCAccount, TESCUser, TESCEvent } from '@Shared/ModelTypes';
-import { Response, Request } from 'express';
-import * as csv from 'fast-csv';
-import { Parser } from 'json2csv';
-import { Service, Inject } from 'typedi';
+import { TESCAccount, TESCUser, TESCEvent, AccountPasswordReset } from '@Shared/ModelTypes';
+import { Request } from 'express';
+import { Service } from 'typedi';
 
 @Service()
 export default class EmailService {
   /**
    * Sends an email with a link to reset an account password.
-   * @param reuqest The web request associated with the email.
+   * @param request The web request associated with the email.
    * @param account The account associated with the request.
+   * @param reset The reset model associated with the account.
    */
-  async sendPasswordResetEmail(request: Request, account: TESCAccount) {
+  async sendPasswordResetEmail(request: Request, account: TESCAccount, reset: AccountPasswordReset) {
     Logger.info(`Sending forgot password email for ${account.email} [${account._id}]`);
 
     return createTESCEmail()
@@ -26,7 +23,7 @@ export default class EmailService {
         },
         locals: {
           account: account,
-          resetUrl: `${request.protocol}://${request.get('host')}/user/reset/${account._id}`,
+          resetUrl: `${request.protocol}://${request.get('host')}/user/reset/${reset.resetString}`,
         },
       });
   }

--- a/src/server/services/ResumeService.ts
+++ b/src/server/services/ResumeService.ts
@@ -4,7 +4,7 @@ import { UserDocument } from '@Models/User';
 import { Response } from 'express';
 import { Parser } from 'json2csv';
 import moment = require('moment');
-import * as generatePassword from 'password-generator';
+import { generate } from 'generate-password';
 import * as S3Archiver from 's3-archiver';
 import { Service, Inject } from 'typedi';
 
@@ -48,7 +48,10 @@ export default class ResumeService {
       const S3FileNames = usersWithResumes.map(file => `${ResumeService.filePrefix}${file.resume.name}`);
 
       if (!outputFileName) {
-        outputFileName = `${moment().format('YYYYMMDDHHmmss')}-${generatePassword(12, false, /[\dA-F]/)}.zip`;
+        const fileRandom = generate({
+          length: 12,
+        });
+        outputFileName = `${moment().format('YYYYMMDDHHmmss')}-${fileRandom}.zip`;
       }
 
       zipper.localConfig.finalizing = (archive, finalizing) =>

--- a/src/server/services/SponsorService.ts
+++ b/src/server/services/SponsorService.ts
@@ -6,7 +6,7 @@ import { AdminModel } from '@Models/Admin';
 import { Admin, Download } from '@Shared/ModelTypes';
 import { Role } from '@Shared/Roles';
 import moment = require('moment');
-import * as generatePassword from 'password-generator';
+import { generate } from 'generate-password';
 import { Service, Inject } from 'typedi';
 
 import ResumeService from './ResumeService';
@@ -70,8 +70,11 @@ export default class SponsorService {
     Logger.info(`Started zipping [${download._id}] ${users.length} users for ${requester.username}`);
 
     try {
+      const fileRandom = generate({
+        length: 12,
+      });
       const outputFileName =
-        `${requester.username}-${moment().format('YYYYMMDDHHmmss')}-${generatePassword(12, false, /[\dA-F]/)}.zip`;
+        `${requester.username}-${moment().format('YYYYMMDDHHmmss')}-${fileRandom}.zip`;
       const s3ZippedFile: any = await this.ResumeService.startZip(users, outputFileName);
 
       download.accessUrl = s3ZippedFile.Location;

--- a/src/server/utils/Errors.ts
+++ b/src/server/utils/Errors.ts
@@ -24,6 +24,7 @@ export const ErrorMessage = {
   INCORRECT_EMAIL_PASSWORD: () => 'Incorrect email or password',
   NO_USERS_SELECTED: () => 'There were no users selected',
   RESUME_ZIPPING_ERROR: () => 'There was an error zipping the resumes',
+  INVALID_RESET: () => 'This reset request is invalid or has expired',
 
   NO_EVENT_ALIAS: () => 'Tried to fetch event without providing event alias',
   NO_REQUEST_USER: () => 'No user in the request headers',

--- a/src/server/views/emails/forgot/html.pug
+++ b/src/server/views/emails/forgot/html.pug
@@ -25,3 +25,5 @@ html
                   img.button(src="https://s3-us-west-1.amazonaws.com/tesc-checkin/public/email-assets/email-reset-button.png")
                 p.refer-text If that link doesn’t work, copy paste this into your browser:
                 a.refer-link(href=resetUrl) #{resetUrl}
+                p.accident-text If you did not request this reset, please contact 
+                  a(href="mailto://hello@tesc.ucsd.edu") hello@tesc.ucsd.edu

--- a/src/server/views/emails/style.css
+++ b/src/server/views/emails/style.css
@@ -29,6 +29,11 @@ h1 {
   margin-bottom: 5px;
 }
 
+.accident-text {
+  font-size: 14px;
+  line-height: 1;
+}
+
 .logo {
   width: 128px;
   height: 128px;

--- a/src/shared/ModelTypes.ts
+++ b/src/shared/ModelTypes.ts
@@ -11,6 +11,14 @@ export enum UserStatus {
   Waitlisted = 'Waitlisted',
 }
 
+export interface AccountPasswordReset {
+  _id?: string & ObjectID;
+  account: TESCAccount;
+  resetString: string;
+  expires: Date;
+  valid: boolean;
+}
+
 export interface UploadedFile {
   name: string;
   size: number;

--- a/src/shared/api/Requests.ts
+++ b/src/shared/api/Requests.ts
@@ -46,7 +46,7 @@ export interface ForgotPasswordRequest {
 }
 
 export interface ResetPasswordRequest {
-  id: string;
+  resetString: string;
   newPassword: string;
 }
 


### PR DESCRIPTION
Instead of using the account ID, this creates a new database element which contains the password reset information:
- Account
- Expiry date (defaults to +1 day)
- Reset string (Unique ID for that reset)
- Valid (whether the reset has been used)

The UI all stayed the same, but the account is now sent a link with the reset string.

This was previously a security flaw, in the case that anyone did somehow get another user's ID. 

Fixes #71 