### PR TITLE
Added getDerivedStateFromProps to re-render on EventPage alerts

### DIFF
--- a/src/client/pages/EventPage/index.tsx
+++ b/src/client/pages/EventPage/index.tsx
@@ -200,6 +200,14 @@ class EventPage extends TabularPage<Props, EventPageState> {
     return (<SettingsTab {...this.props} />);
   }
 
+  static getDerivedStateFromProps(props: Props, state: EventPageState) {
+    if (props.alerts != state.alerts) {
+      return {
+        alerts: props.alerts
+      }
+    }
+  }
+
   render() {
     const { event, statistics, alerts } = this.props;
     const { activeTab } = this.state;


### PR DESCRIPTION
We usually directly use [AlertPage.createAlert](https://github.com/UCSDTESC/Check-in/blob/0657d1d42ad3530eb6e43557a71d36887478b127/src/client/pages/UserPage/index.tsx#L111) to update state and show an alert on any page that inherits AlertPage. 

EventPage puts its alert state into redux state, which meant that the actual alert data was in the props instead of the state.

Fixes #138 