### PR TITLE
Event Editing

### DIFF
--- a/src/assets/scss/pages/_event.scss
+++ b/src/assets/scss/pages/_event.scss
@@ -55,4 +55,8 @@
       padding-right: 5rem;
     }
   }
+
+  &__edit-form {
+    padding: 25px;
+  }
 }

--- a/src/client/components/EventForm.tsx
+++ b/src/client/components/EventForm.tsx
@@ -122,7 +122,7 @@ class EventForm extends React.Component<Props> {
             type="submit"
             disabled={pristine || submitting}
           >
-              {this.props.editing ? 'Edit Event' : 'Create Event!'}
+              {this.props.editing ? 'Edit Event' : 'Create Event'}
           </button>
         )}
       </form>
@@ -131,6 +131,6 @@ class EventForm extends React.Component<Props> {
 }
 
 export default reduxForm<EventFormData, EventFormProps>({
-  form: 'newEvent',
+  form: 'event',
   destroyOnUnmount: true,
 })(EventForm);

--- a/src/client/components/EventForm.tsx
+++ b/src/client/components/EventForm.tsx
@@ -3,7 +3,7 @@ import { Field, Fields, reduxForm, InjectedFormProps, WrappedFieldsProps } from 
 import * as FormFields from '~/components/Fields';
 import FileField from '~/components/FileField';
 
-export interface NewEventFormData {
+export interface EventFormData {
   name: string;
   alias: string;
   closeTimeDay: number;
@@ -17,13 +17,13 @@ export interface NewEventFormData {
   logo: File[];
 }
 
-interface NewEventFormProps {
+interface EventFormProps {
 
 }
 
-type Props = InjectedFormProps<NewEventFormData, NewEventFormProps> & NewEventFormProps;
+type Props = InjectedFormProps<EventFormData, EventFormProps> & EventFormProps;
 
-class NewEventForm extends React.Component<Props> {
+class EventForm extends React.Component<Props> {
 
   createLogoUpload() {
     return (
@@ -130,7 +130,7 @@ class NewEventForm extends React.Component<Props> {
   }
 }
 
-export default reduxForm<NewEventFormData, NewEventFormProps>({
+export default reduxForm<EventFormData, EventFormProps>({
   form: 'newEvent',
   destroyOnUnmount: true,
-})(NewEventForm);
+})(EventForm);

--- a/src/client/components/EventForm.tsx
+++ b/src/client/components/EventForm.tsx
@@ -18,7 +18,7 @@ export interface EventFormData {
 }
 
 interface EventFormProps {
-
+  editing?: boolean;
 }
 
 type Props = InjectedFormProps<EventFormData, EventFormProps> & EventFormProps;
@@ -122,7 +122,7 @@ class EventForm extends React.Component<Props> {
             type="submit"
             disabled={pristine || submitting}
           >
-              Create Event!
+              {this.props.editing ? 'Edit Event!' : 'Create Event!'}
           </button>
         )}
       </form>

--- a/src/client/components/EventForm.tsx
+++ b/src/client/components/EventForm.tsx
@@ -122,7 +122,7 @@ class EventForm extends React.Component<Props> {
             type="submit"
             disabled={pristine || submitting}
           >
-              {this.props.editing ? 'Edit Event!' : 'Create Event!'}
+              {this.props.editing ? 'Edit Event' : 'Create Event!'}
           </button>
         )}
       </form>

--- a/src/client/components/Fields.tsx
+++ b/src/client/components/Fields.tsx
@@ -106,7 +106,7 @@ export const errorMonthPicker: React.StatelessComponent<CustomFieldProps> = ({ i
   return (
     <div>
       <select
-        {...{...input, value: input.value + 1}}
+        {...input}
         className={errorClassName}
       >
         <option key={-1}>Month</option>

--- a/src/client/components/Fields.tsx
+++ b/src/client/components/Fields.tsx
@@ -111,7 +111,7 @@ export const errorMonthPicker: React.StatelessComponent<CustomFieldProps> = ({ i
       >
         <option key={-1}>Month</option>
         {months.map((month, i) => (
-          <option key={i} value={i + 1}>
+          <option key={i} value={i}>
             {month}
           </option>),
         )}

--- a/src/client/components/Fields.tsx
+++ b/src/client/components/Fields.tsx
@@ -96,8 +96,7 @@ export const errorTextArea: React.StatelessComponent<CustomFieldProps> = ({ inpu
   );
 };
 
-export const errorMonthPicker: React.StatelessComponent<CustomFieldProps> = ({ input, className,
-  meta: { touched, error } }) => {
+export const errorMonthPicker: React.StatelessComponent<CustomFieldProps> = ({ input, className, meta: { touched, error } }) => {
   const errorClassName = errorClass(className, touched, error);
   const months = [
     'January', 'February', 'March', 'April', 'May', 'June', 'July', 'August',
@@ -107,7 +106,7 @@ export const errorMonthPicker: React.StatelessComponent<CustomFieldProps> = ({ i
   return (
     <div>
       <select
-        {...input}
+        {...{...input, value: input.value + 1}}
         className={errorClassName}
       >
         <option key={-1}>Month</option>
@@ -278,12 +277,12 @@ export function createTextArea(name: string, placeholder: string,
   );
 }
 
-export function createMonthPicker(name: string = null) {
+export function createMonthPicker(name = 'birthdateMonth') {
   return (
     <Field
       component={errorMonthPicker}
       className="sd-form__input-select mb-1 mb-md-0"
-      name={`${name || 'birthdateMonth'}`}
+      name={name}
     />
   );
 }

--- a/src/client/data/AdminApi.ts
+++ b/src/client/data/AdminApi.ts
@@ -187,6 +187,32 @@ export const registerNewEvent = (event: EventFormData) => {
   );
 };
 
+export const editExistingEvent = (id: string, event: Partial<EventFormData>) => {
+  const { logo, closeTimeDay, closeTimeMonth, closeTimeYear, ...eventWithoutFields } = event;
+  const closeTime: string = moment(new Date(
+    closeTimeYear,
+    closeTimeMonth - 1,
+    closeTimeDay
+  )).toISOString(true);
+
+  
+  const promiseReq = request
+    .post(`/events/edit/${id}`)
+    .set('Authorization', cookies.get(CookieTypes.admin.token))
+    .field('event', JSON.stringify({
+      ...eventWithoutFields,
+      closeTime,
+    } as RegisterEventRequest))
+    .use(adminApiPrefix)
+    .use(nocache)
+
+    if (logo) {
+      promiseReq.attach('logo', logo[0])
+    }
+
+    return promisify<TESCEvent>(promiseReq);
+}
+
 /**
  * Request to register a new admin.
  * @param {Object} admin The admin fields to register.

--- a/src/client/data/AdminApi.ts
+++ b/src/client/data/AdminApi.ts
@@ -210,7 +210,7 @@ export const editExistingEvent = (id: string, event: Partial<EventFormData>) => 
       promiseReq.attach('logo', logo[0])
     }
 
-    return promisify<TESCEvent>(promiseReq);
+    return promisify<void>(promiseReq);
 }
 
 /**

--- a/src/client/data/AdminApi.ts
+++ b/src/client/data/AdminApi.ts
@@ -170,7 +170,7 @@ export const registerNewEvent = (event: EventFormData) => {
   const { logo, closeTimeDay, closeTimeMonth, closeTimeYear, ...eventWithoutFields } = event;
   const closeTime: string = moment(new Date(
     closeTimeYear,
-    closeTimeMonth - 1,
+    closeTimeMonth,
     closeTimeDay
   )).toISOString(true);
   return promisify<TESCEvent>(
@@ -191,7 +191,7 @@ export const editExistingEvent = (id: string, event: Partial<EventFormData>) => 
   const { logo, closeTimeDay, closeTimeMonth, closeTimeYear, ...eventWithoutFields } = event;
   const closeTime: string = moment(new Date(
     closeTimeYear,
-    closeTimeMonth - 1,
+    closeTimeMonth,
     closeTimeDay
   )).toISOString(true);
 

--- a/src/client/data/AdminApi.ts
+++ b/src/client/data/AdminApi.ts
@@ -24,7 +24,7 @@ import nocache from 'superagent-no-cache';
 import pref from 'superagent-prefix';
 import Cookies from 'universal-cookie';
 import { NewAdminModalFormData } from '~/components/NewAdminModal';
-import { NewEventFormData } from '~/pages/NewEventPage/components/NewEventForm';
+import { EventFormData } from '~/components/EventForm';
 import CookieTypes from '~/static/Cookies';
 
 import { promisify } from './helpers';
@@ -166,7 +166,7 @@ export const checkinUser = (id: string, eventId: string) =>
       .use(adminApiPrefix)
   );
 
-export const registerNewEvent = (event: NewEventFormData) => {
+export const registerNewEvent = (event: EventFormData) => {
   const { logo, closeTimeDay, closeTimeMonth, closeTimeYear, ...eventWithoutFields } = event;
   const closeTime: string = moment(new Date(
     closeTimeYear,

--- a/src/client/pages/EventPage/index.tsx
+++ b/src/client/pages/EventPage/index.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import FA from 'react-fontawesome';
 import { connect } from 'react-redux';
 import { showLoading, hideLoading } from 'react-redux-loading-bar';
-import { Link, RouteComponentProps } from 'react-router-dom';
+import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
 import { UncontrolledTooltip } from 'reactstrap';
 import { bindActionCreators } from 'redux';
 import { loadAllAdminEvents, ApplicationDispatch, loadAvailableColumns } from '~/actions';
@@ -220,7 +220,7 @@ class EventPage extends TabularPage<Props, EventPageState> {
    * @returns {Component} The edit tab
    */
   renderEditForm() {
-    const validator = createValidator();
+    const validator = createValidator(false);
     const eventDate = new Date(this.props.event.closeTime);
     const initialValues: Partial<EventFormData> = {
       ...this.props.event,
@@ -233,22 +233,25 @@ class EventPage extends TabularPage<Props, EventPageState> {
     const editEvent = async (eventData: EventFormData) => {
       try {
         await editExistingEvent(this.props.event._id, eventData);
-        this.props.loadAllAdminEvents();
         this.props.addEventSuccessAlert(eventData.alias, `Successfully edited ${eventData.name}`, 'Edit Event');
+        await this.props.loadAllAdminEvents();
+        if (eventData.alias !== this.props.match.params.eventAlias) {
+          this.props.history.replace(`/admin/events/${eventData.alias}#edit`);
+        }
       } catch (e) {
         this.props.addEventDangerAlert(eventData.alias, e.message, 'Edit Event');
       }
     }
 
     return (
-          <div className="sd-form">
-            <EventForm
-              editing
-              validate={validator}
-              onSubmit={editEvent}
-              initialValues={initialValues}
-            />
-          </div>
+        <div className="sd-form event-page__edit-form">
+          <EventForm
+            editing
+            validate={validator}
+            onSubmit={editEvent}
+            initialValues={initialValues}
+          />
+        </div>
     );
   }
 
@@ -332,4 +335,6 @@ class EventPage extends TabularPage<Props, EventPageState> {
   }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(EventPage);
+export default withRouter(
+  connect(mapStateToProps, mapDispatchToProps)(EventPage)
+);

--- a/src/client/pages/EventPage/index.tsx
+++ b/src/client/pages/EventPage/index.tsx
@@ -97,16 +97,16 @@ class EventPage extends TabularPage<Props, EventPageState> {
       render: this.renderAdministrators.bind(this),
     } as TabPage,
     {
+      icon: 'edit',
+      name: 'Edit',
+      anchor: 'edit',
+      render: this.renderEditForm.bind(this),
+    } as TabPage,
+    {
       icon: 'cog',
       name: 'Settings',
       anchor: 'settings',
       render: this.renderSettings.bind(this),
-    } as TabPage,
-    {
-      icon: 'cog',
-      name: 'Edit',
-      anchor: 'edit',
-      render: this.renderEditForm.bind(this),
     } as TabPage,
   ];
 
@@ -250,6 +250,7 @@ class EventPage extends TabularPage<Props, EventPageState> {
               </UncontrolledAlert>
             )}
             <EventForm
+              editing
               validate={validator}
               onSubmit={editEvent}
               initialValues={initialValues}

--- a/src/client/pages/EventPage/index.tsx
+++ b/src/client/pages/EventPage/index.tsx
@@ -224,8 +224,8 @@ class EventPage extends TabularPage<Props, EventPageState> {
     const eventDate = new Date(this.props.event.closeTime);
     const initialValues: Partial<EventFormData> = {
       ...this.props.event,
-      closeTimeDay: eventDate.getDay(),
-      closeTimeMonth: eventDate.getMonth() + 1,
+      closeTimeDay: eventDate.getDate(),
+      closeTimeMonth: eventDate.getMonth(),
       closeTimeYear: eventDate.getFullYear(),
       logo: undefined,
     }

--- a/src/client/pages/EventPage/index.tsx
+++ b/src/client/pages/EventPage/index.tsx
@@ -27,7 +27,6 @@ import TeamsTab from './tabs/TeamsTab';
 import ViewApplication from './components/ViewApplication';
 import EventForm, { EventFormData } from '../../components/EventForm';
 import createValidator from '../NewEventPage/validate';
-import { UncontrolledAlert } from 'reactstrap/lib/Uncontrolled';
 
 type RouteProps = RouteComponentProps<{
   eventAlias: string;
@@ -65,7 +64,6 @@ export type Props = RouteProps & ReturnType<typeof mapStateToProps> &
 
 interface EventPageState extends TabularPageState {
   teams: TESCTeam[];
-  err?: string;
 }
 
 class EventPage extends TabularPage<Props, EventPageState> {
@@ -229,26 +227,21 @@ class EventPage extends TabularPage<Props, EventPageState> {
       closeTimeDay: eventDate.getDay(),
       closeTimeMonth: eventDate.getMonth() + 1,
       closeTimeYear: eventDate.getFullYear(),
-      logo: undefined, // TODO: Figure out logo
+      logo: undefined,
     }
 
     const editEvent = async (eventData: EventFormData) => {
       try {
-        const event = await editExistingEvent(this.props.event._id, eventData);
-        this.setState({ err: null });
-        this.props.addEventSuccessAlert(event.alias, `Successfully edited ${event.name}`, 'Edit Event');
+        await editExistingEvent(this.props.event._id, eventData);
+        this.props.loadAllAdminEvents();
+        this.props.addEventSuccessAlert(eventData.alias, `Successfully edited ${eventData.name}`, 'Edit Event');
       } catch (e) {
-        this.setState({ err: e.message });
+        this.props.addEventDangerAlert(eventData.alias, e.message, 'Edit Event');
       }
     }
 
     return (
           <div className="sd-form">
-            {this.state.err && (
-              <UncontrolledAlert color="danger">
-                {this.state.err}
-              </UncontrolledAlert>
-            )}
             <EventForm
               editing
               validate={validator}

--- a/src/client/pages/EventPage/index.tsx
+++ b/src/client/pages/EventPage/index.tsx
@@ -27,6 +27,8 @@ import SettingsTab from './tabs/SettingsTab';
 import StatisticsTab from './tabs/StatisticsTab';
 import TeamsTab from './tabs/TeamsTab';
 import ViewApplication from './components/ViewApplication';
+import EventForm, { EventFormData } from '../../components/EventForm';
+import createValidator from '../NewEventPage/validate';
 
 type RouteProps = RouteComponentProps<{
   eventAlias: string;
@@ -99,6 +101,12 @@ class EventPage extends TabularPage<Props, EventPageState> {
       name: 'Settings',
       anchor: 'settings',
       render: this.renderSettings.bind(this),
+    } as TabPage,
+    {
+      icon: 'cog',
+      name: 'Edit',
+      anchor: 'edit',
+      render: this.renderEditForm.bind(this),
     } as TabPage,
   ];
 
@@ -207,6 +215,33 @@ class EventPage extends TabularPage<Props, EventPageState> {
    */
   renderSettings() {
     return (<SettingsTab {...this.props} />);
+  }
+
+  /**
+   * Renders the event tab for editing the ebemt.
+   * @returns {Component} The edit tab
+   */
+  renderEditForm() {
+    const validator = createValidator();
+    const eventDate = new Date(this.props.event.closeTime);
+    const initialValues: Partial<EventFormData> = {
+      ...this.props.event,
+      closeTimeDay: eventDate.getDay(),
+      closeTimeMonth: eventDate.getMonth(),
+      closeTimeYear: eventDate.getFullYear(),
+      logo: undefined, // TODO: Figure out logo
+    }
+
+    return (
+          <div className="sd-form">
+            <EventForm
+              validate={validator}
+              // onSubmit={this.createNewEvent} // TODO
+              initialValues={initialValues}
+            />
+          </div>
+    )
+    
   }
 
   render() {

--- a/src/client/pages/NewEventPage/index.tsx
+++ b/src/client/pages/NewEventPage/index.tsx
@@ -10,7 +10,7 @@ import { registerNewEvent } from '~/data/AdminApi';
 
 import { addEventSuccessAlert } from '../EventPage/actions';
 
-import NewEventForm, { NewEventFormData } from './components/NewEventForm';
+import EventForm, { EventFormData } from '~/components/EventForm';
 import createValidator from './validate';
 
 const mapDispatchToProps = (dispatch: ApplicationDispatch) => bindActionCreators({
@@ -33,7 +33,7 @@ class NewEventPage extends React.Component<Props, NewEventPageState> {
     err: null,
   };
 
-  createNewEvent = (event: NewEventFormData) => {
+  createNewEvent = (event: EventFormData) => {
     registerNewEvent(event)
       .then((res: TESCEvent) => {
         this.setState({ err: null });
@@ -60,7 +60,7 @@ class NewEventPage extends React.Component<Props, NewEventPageState> {
 
         <div className="sd-form__wrapper">
           <div className="sd-form">
-            <NewEventForm
+            <EventForm
               validate={validator}
               onSubmit={this.createNewEvent}
               initialValues={{ organisedBy: 'TESC' }}

--- a/src/client/pages/NewEventPage/validate.ts
+++ b/src/client/pages/NewEventPage/validate.ts
@@ -15,8 +15,8 @@ const createValidator = () => (values: any) => {
     errors.closeTimeDay = 'Invalid Day';
   }
 
-  if (values.closeTimeMonth === 'Month' || values.closeTimeMonth < 1 ||
-    values.closeTimeMonth > 12) {
+  if (values.closeTimeMonth === 'Month' || values.closeTimeMonth < 0 ||
+    values.closeTimeMonth > 11) {
     errors.closeTimeMonth = 'Invalid Month';
   }
 

--- a/src/client/pages/NewEventPage/validate.ts
+++ b/src/client/pages/NewEventPage/validate.ts
@@ -1,10 +1,13 @@
-const createValidator = () => (values: any) => {
+const createValidator = (requireLogo = true) => (values: any) => {
+  console.log(values)
   const errors: any = {};
 
   const required = ['name', 'alias', 'closeTimeMonth', 'closeTimeDay',
-    'closeTimeYear', 'email', 'homepage', 'description', 'logo'];
+    'closeTimeYear', 'email', 'homepage', 'description'];
 
-  const notValid = required.filter(name => !(name in values));
+  requireLogo && required.push('logo')
+
+  const notValid = required.filter(name => !(name in values) || !values[name]);
   notValid.forEach(name => errors[name] = 'Required');
 
   if (!/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i.test(values.email)) {

--- a/src/server/api/controllers/admin/EventsController.ts
+++ b/src/server/api/controllers/admin/EventsController.ts
@@ -75,6 +75,17 @@ export class EventsController {
     return newEvent;
   }
 
+  @Post('/edit/:eventId')
+  @UseBefore(RoleAuth(Role.ROLE_ADMIN))
+  async editExistingEvent(
+    @Param('eventId') id: string,
+    @BodyParam('event') event: RegisterEventRequest,
+    @UploadedFile('logo', { options: Uploads, required: false }) logo?: Express.Multer.File,
+  ) {
+    await this.EventService.editExistingEvent(id, event, logo ? logo.path : undefined);
+    return SuccessResponse.Positive;
+  }
+
   @Put('/')
   @UseBefore(RoleAuth(Role.ROLE_ADMIN))
   async updateEventOptions(@Body() body: UpdateEventOptionsRequest) {

--- a/src/server/config/Passport.ts
+++ b/src/server/config/Passport.ts
@@ -69,7 +69,7 @@ export class PassportStrategy {
   public getJWTAdminLogin() {
     return new JwtStrategy(jwtOptions, (payload, done) => {
       this.AdminModel.findById(payload._id, (err, user) => {
-        if (err || !user || user.deleted) {
+        if (err || user.deleted) {
           return done(err, false);
         }
 

--- a/src/server/config/Passport.ts
+++ b/src/server/config/Passport.ts
@@ -69,7 +69,7 @@ export class PassportStrategy {
   public getJWTAdminLogin() {
     return new JwtStrategy(jwtOptions, (payload, done) => {
       this.AdminModel.findById(payload._id, (err, user) => {
-        if (err || user.deleted) {
+        if (err || !user || user.deleted) {
           return done(err, false);
         }
 

--- a/src/server/services/EventService.ts
+++ b/src/server/services/EventService.ts
@@ -320,6 +320,22 @@ export default class EventService {
   }
 
   /**
+   * Edits an existing event with given attributes.
+   * @param request The request with event parameters.
+   * @param logoPath The file path of the logo to associate with the new event.
+   */
+  async editExistingEvent(id: string, request: Partial<RegisterEventRequest>, logoPath?: string) {
+    const event = await this.EventModel.findByIdAndUpdate(id, request);
+    if (logoPath) {
+      try {
+        await event.attach('logo', { path: logoPath });
+      } catch (err) {
+        throw new Error(ErrorMessage.DATABASE_ERROR());
+      }
+    }
+  }
+
+  /**
    * Determines whether an event's registration is still publicly open.
    * @param event The event for which to check.
    */

--- a/src/server/services/EventService.ts
+++ b/src/server/services/EventService.ts
@@ -333,6 +333,7 @@ export default class EventService {
         throw new Error(ErrorMessage.DATABASE_ERROR());
       }
     }
+    await event.save();
   }
 
   /**


### PR DESCRIPTION
- Adds an `edit` tab to events.
- Autofills all form information when editing
- Adds `/events/edit/:id` to the backend: works the same way a `/events` POST would work.
- Fixes a small bug in user sign-in validation (got me a few times when trying to set up)