### PR TITLE
Fixed Redux Subscription To Allow Multiple User SubComponents Openabl…

### DIFF
--- a/src/client/components/User.tsx
+++ b/src/client/components/User.tsx
@@ -448,7 +448,6 @@ class User extends React.Component<Props> {
 }
 
 export default reduxForm<UserFormData, UserProps>({
-  form: UUID.v4(),
   destroyOnUnmount: true,
   enableReinitialize: true,
 })(connect(mapStateToProps)(User));

--- a/src/client/pages/UsersPage/components/UserList.tsx
+++ b/src/client/pages/UsersPage/components/UserList.tsx
@@ -24,6 +24,7 @@ class UserList extends React.Component<UserListProps> {
         user={row}
         event={this.props.event}
         initialValues={row}
+        form={row._id}
         onSubmit={this.props.onUserUpdate}
         createAlert={this.props.createAlert}
       />


### PR DESCRIPTION
…e At Once

Fixes that one bug we haven't been able to track down where opening two users on UsersPage interpolates their data. 

Turns out, ES6 Modules would not re-run the `export default` line for 2 instances of the same component, meaning that our intended implementation of calling `UUID.v4()` on a per component basis never happened - the module gen'd a UUID once and used the same UUID for all of the expanded rows, meaning data would get mixed up between instances.

Here is the confirmation that our redux data model actually works now :) 

![image](https://user-images.githubusercontent.com/23143381/74207067-d4c55780-4c32-11ea-811f-5d249f108c1c.png)


